### PR TITLE
fix: Always initialize map that holds plugin data

### DIFF
--- a/saturn.go
+++ b/saturn.go
@@ -60,6 +60,10 @@ type Context struct {
 }
 
 func newContext(c *protocolv1.Context) Context {
+	if c != nil && c.PluginData == nil {
+		c.PluginData = make(map[string]string)
+	}
+
 	return Context{
 		Context:      c,
 		TemplateVars: make(map[string]string),

--- a/saturn_test.go
+++ b/saturn_test.go
@@ -72,10 +72,8 @@ func TestProvider_ExecuteActions_ApplySucceeds(t *testing.T) {
 	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	req := &protocolv1.ExecuteActionsRequest{
-		Context: &protocolv1.Context{
-			PluginData: make(map[string]string),
-		},
-		Path: dir,
+		Context: &protocolv1.Context{},
+		Path:    dir,
 	}
 
 	p := &provider{plugin: p1}
@@ -94,9 +92,7 @@ func TestProvider_ExecuteFilters_Succeed(t *testing.T) {
 		filterReturn: true,
 	}
 	req := &protocolv1.ExecuteFiltersRequest{
-		Context: &protocolv1.Context{
-			PluginData: make(map[string]string),
-		},
+		Context: &protocolv1.Context{},
 	}
 
 	p := &provider{plugin: p1}


### PR DESCRIPTION
Without this fix, the code panics because the `map` is `nil`.